### PR TITLE
login comand in order to remeber credentials

### DIFF
--- a/bin/hack-spirit
+++ b/bin/hack-spirit
@@ -2,10 +2,11 @@
 
 'use strict';
 
-let program = require('commander');
-let moment  = require('moment');
-let prompt  = require('prompt');
-let colors  = require('colors/safe');
+let program    = require('commander');
+let moment     = require('moment');
+let prompt     = require('prompt');
+let colors     = require('colors/safe');
+let HackSpirit = require('../lib/hack-spirit');
 
 prompt.message   = '';
 prompt.delimiter = '';
@@ -23,7 +24,6 @@ program
   .command('login')
   .description('login with your team sprint credentials')
   .action(() => {
-    let HackSpirit = require('../lib/hack-spirit');
     if (program.user && program.password) {
       let hackSpirit = new HackSpirit(program.browser, program.verbose);
       hackSpirit.login(program.user, program.password)
@@ -50,7 +50,6 @@ program
   .command('work_status')
   .description('print current work status')
   .action(() => {
-    let HackSpirit = require('../lib/hack-spirit');
     let hackSpirit = new HackSpirit(program.browser, program.verbose);
     hackSpirit.printWorkStatus(program.user, program.password);
   });
@@ -58,7 +57,6 @@ program
   .command('start_work')
   .description('start work')
   .action(() => {
-      let HackSpirit = require('../lib/hack-spirit');
       let hackSpirit = new HackSpirit(program.browser, program.verbose);
       hackSpirit.startWork(program.user, program.password);
   });
@@ -67,7 +65,6 @@ program
   .command('finish_work')
   .description('finish_work')
   .action(() => {
-      let HackSpirit = require('../lib/hack-spirit');
       let hackSpirit = new HackSpirit(program.browser, program.verbose);
       hackSpirit.finishWork(program.user, program.password);
   });
@@ -84,6 +81,7 @@ program
       let date = opts.datetime ? moment(opts.datetime, dateFormat).toDate() : new Date();
       let note = opts.note ? opts.note : defaultNote;
       let HackSpirit = require('../lib/hack-spirit');
+
       let hackSpirit = new HackSpirit(program.browser, program.verbose);
       hackSpirit.askForOvertime(program.user, program.password, date, note);
   });

--- a/bin/hack-spirit
+++ b/bin/hack-spirit
@@ -4,6 +4,13 @@
 
 let program = require('commander');
 let moment  = require('moment');
+let prompt  = require('prompt');
+let colors  = require('colors/safe');
+
+prompt.message   = '';
+prompt.delimiter = '';
+
+let w = colors.white;
 
 program
   .version('0.0.3')
@@ -12,6 +19,33 @@ program
   .option('-v, --verbose', 'print log')
   .option('-b, --browser', 'show browser');
 
+program
+  .command('login')
+  .description('login with your team sprint credentials')
+  .action(() => {
+    let HackSpirit = require('../lib/hack-spirit');
+    if (program.user && program.password) {
+      let hackSpirit = new HackSpirit(program.browser, program.verbose);
+      hackSpirit.login(program.user, program.password)
+      return
+    }
+    let schema = {
+      properties: {
+              user: { required: true, description: w('User:') },
+          password: { required: true, description: w('Password'), hidden: true }
+      }
+    };
+    console.log('Enter your team spirit credentials.')
+    prompt.start()
+    prompt.get(schema, function (error, result) {
+      if (error) {
+         console.log('Sorry, something wrong: ' + error);
+         return;
+      }
+      let hackSpirit = new HackSpirit(program.browser, program.verbose);
+      hackSpirit.login(result.user, result.password)
+    });
+  });
 program
   .command('work_status')
   .description('print current work status')

--- a/bin/hack-spirit
+++ b/bin/hack-spirit
@@ -86,6 +86,12 @@ program
       hackSpirit.askForOvertime(program.user, program.password, date, note);
   });
 
+program
+  .command('*', '', { noHelp: true})
+  .action(() => {
+    program.outputHelp();
+  });
+
 program.parse(process.argv);
 
 if (!process.argv.slice(2).length) {

--- a/lib/credential.js
+++ b/lib/credential.js
@@ -1,0 +1,50 @@
+'use strict';
+
+let keychain = require('keychain');
+
+const StoreType = {
+  Keychain : 'keychain'
+};
+
+class Credential {
+  constructor() {
+    this.type = StoreType.Keychain;
+  }
+
+  * set(userName, password) {
+    return new Promise((resolve, reject) => {
+      keychain.setPassword({
+        account: 'hack-spirit',
+        service: 'hack-spirit.com',
+           type: 'internet',
+       password: JSON.stringify({ userName: userName, password: password})
+      }, (error) => {
+        if (error) {
+          let message = 'Failed to set your credentials to keychain';
+          reject(new Error(message));
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  * get() {
+    return new Promise((resolve, reject) => {
+      keychain.getPassword({
+        account: 'hack-spirit',
+        service: 'hack-spirit.com',
+           type: 'internet'
+      }, function(error, password) {
+        if (error) {
+          let message = 'Failed to get your credentials to keychain';
+          reject(new Error(message));
+        } else {
+          resolve(JSON.parse(password));
+        }
+      });
+    });
+  }
+}
+
+module.exports = Credential;

--- a/lib/credential.js
+++ b/lib/credential.js
@@ -35,9 +35,9 @@ class Credential {
         account: 'hack-spirit',
         service: 'hack-spirit.com',
            type: 'internet'
-      }, function(error, password) {
+      }, (error, password) => {
         if (error) {
-          let message = 'Failed to get your credentials to keychain';
+          let message = 'Credentails is not found. Please login first.';
           reject(new Error(message));
         } else {
           resolve(JSON.parse(password));

--- a/lib/credential.js
+++ b/lib/credential.js
@@ -1,17 +1,34 @@
 'use strict';
 
-let keychain = require('keychain');
+let keychain  = require('keychain');
+let crypto    = require("crypto");
+let os        = require('os');
+let fs        = require('fs');
+let mkdirp    = require('mkdirp');
+let osHomedir = require('os-homedir');
 
 const StoreType = {
-  Keychain : 'keychain'
+  Keychain: 'keychain',
+  File    : 'file'
 };
+
+const cryptoPassword = 'hack-spirit-credetial';
+const algorithm      = 'aes-256-ctr';
 
 class Credential {
   constructor() {
-    this.type = StoreType.Keychain;
+    if (os.type() === 'Darwin') {
+      this.type = StoreType.Keychain;
+      this.set  = this.setWithKeychain;
+      this.get  = this.getWithKeychain;
+    } else {
+      this.type = StoreType.File;
+      this.set  = this.setWithFile;
+      this.get  = this.getWithFile;
+    }
   }
 
-  * set(userName, password) {
+  * setWithKeychain(userName, password) {
     return new Promise((resolve, reject) => {
       keychain.setPassword({
         account: 'hack-spirit',
@@ -29,7 +46,27 @@ class Credential {
     });
   }
 
-  * get() {
+  * setWithFile(userName, password) {
+    let data = JSON.stringify({ userName: userName, password: password});
+    let cipher = crypto.createCipher(algorithm, cryptoPassword);
+    var ciphered = cipher.update(data, 'utf8', 'hex');
+    ciphered += cipher.final('hex');
+
+    return new Promise((resolve, reject) => {
+      let dir = `${osHomedir()}/.hackspirit`;
+      mkdirp(dir, () => {
+        fs.writeFile(`${dir}/auth`, ciphered, 'utf8', (error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+    });
+  }
+
+  * getWithKeychain() {
     return new Promise((resolve, reject) => {
       keychain.getPassword({
         account: 'hack-spirit',
@@ -41,6 +78,23 @@ class Credential {
           reject(new Error(message));
         } else {
           resolve(JSON.parse(password));
+        }
+      });
+    });
+  }
+
+  * getWithFile() {
+    return new Promise((resolve, reject) => {
+      let dir = `${osHomedir()}/.hackspirit`;
+      fs.readFile(`${dir}/auth`, 'utf8', (error, ciphered) => {
+        if (error) {
+          let message = 'Credentails is not found. Please login first.';
+          reject(new Error(message));
+        } else {
+          let decipher = crypto.createDecipher(algorithm, cryptoPassword);
+          var data = decipher.update(ciphered, 'hex', 'utf8');
+          data += decipher.final('utf8');
+          resolve(JSON.parse(data));
         }
       });
     });

--- a/lib/hack-spirit.js
+++ b/lib/hack-spirit.js
@@ -21,7 +21,7 @@ class HackSpirit {
   }
 
   login(userName, password) {
-    var self = this;
+    let self = this;
     if (!userName || !password) {
       self.print('user name or password is invalied');
       self.dispose();
@@ -39,7 +39,7 @@ class HackSpirit {
   }
 
   printWorkStatus(userName, password) {
-    var self = this;
+    let self = this;
     co(function *() {
       if (!userName || !password) {
         let credential = yield new Credential().get();
@@ -51,7 +51,7 @@ class HackSpirit {
       yield self.teamSpiritClient.login(userName, password);
       self.log('complete logging in... ');
       self.log('fetching work status');
-      var workStatus = yield self.teamSpiritClient.fetchWorkStatus();
+      let workStatus = yield self.teamSpiritClient.fetchWorkStatus();
       self.log('complete fetching work status');
       self.print(workStatus);
       self.teamSpiritClient.dispose();
@@ -64,7 +64,7 @@ class HackSpirit {
   }
 
   startWork(userName, password) {
-    var self = this;
+    let self = this;
     co(function *() {
       if (!userName || !password) {
         let credential = yield new Credential().get();
@@ -72,8 +72,8 @@ class HackSpirit {
         if (!password) password = credential.password;
       }
 
-      var cookies    = yield self.teamSpiritClient.login(userName, password);
-      var workStatus = yield self.teamSpiritClient.fetchWorkStatus();
+      let cookies    = yield self.teamSpiritClient.login(userName, password);
+      let workStatus = yield self.teamSpiritClient.fetchWorkStatus();
       if (workStatus !== WorkStatus.BeforeWorking) {
         return Promise.reject(`you are already working. (status=${workStatus})`);
       }
@@ -85,14 +85,14 @@ class HackSpirit {
   }
 
   finishWork(userName, password) {
-    var self = this;
+    let self = this;
     co(function *() {
       let auth = yield new Credential().get();
       if (!userName) userName = auth.userName;
       if (!password) password = auth.password;
 
-      var cookies    = yield self.teamSpiritClient.login(userName, password);
-      var workStatus = yield self.teamSpiritClient.fetchWorkStatus();
+      let cookies    = yield self.teamSpiritClient.login(userName, password);
+      let workStatus = yield self.teamSpiritClient.fetchWorkStatus();
       if (workStatus !== WorkStatus.Working) {
         return Promise.reject(`you are not working. (status=${workStatus})`);
       }
@@ -104,8 +104,8 @@ class HackSpirit {
   }
 
   askForOvertime(userName, password, date, note) {
-    var self = this;
-    var ts = self.teamSpiritClient;
+    let self = this;
+    let ts = self.teamSpiritClient;
     co(function *() {
       if (!userName || !password) {
         let auth = yield new Credential().get();

--- a/lib/hack-spirit.js
+++ b/lib/hack-spirit.js
@@ -41,6 +41,12 @@ class HackSpirit {
   printWorkStatus(userName, password) {
     var self = this;
     co(function *() {
+      if (!userName || !password) {
+        let credential = yield new Credential().get();
+        if (!userName) userName = credential.userName;
+        if (!password) password = credential.password;
+      }
+
       self.log('logging in... ');
       yield self.teamSpiritClient.login(userName, password);
       self.log('complete logging in... ');
@@ -60,6 +66,12 @@ class HackSpirit {
   startWork(userName, password) {
     var self = this;
     co(function *() {
+      if (!userName || !password) {
+        let credential = yield new Credential().get();
+        if (!userName) userName = credential.userName;
+        if (!password) password = credential.password;
+      }
+
       var cookies    = yield self.teamSpiritClient.login(userName, password);
       var workStatus = yield self.teamSpiritClient.fetchWorkStatus();
       if (workStatus !== WorkStatus.BeforeWorking) {
@@ -75,6 +87,10 @@ class HackSpirit {
   finishWork(userName, password) {
     var self = this;
     co(function *() {
+      let auth = yield new Credential().get();
+      if (!userName) userName = auth.userName;
+      if (!password) password = auth.password;
+
       var cookies    = yield self.teamSpiritClient.login(userName, password);
       var workStatus = yield self.teamSpiritClient.fetchWorkStatus();
       if (workStatus !== WorkStatus.Working) {
@@ -91,6 +107,12 @@ class HackSpirit {
     var self = this;
     var ts = self.teamSpiritClient;
     co(function *() {
+      if (!userName || !password) {
+        let auth = yield new Credential().get();
+        if (!userName) userName = auth.userName;
+        if (!password) password = auth.password;
+      }
+
       let cookies    = yield ts.login(userName, password);
       yield ts.askForOvertime(date, note);
       let d = moment(date).format("YYYYMMDDHHmm");

--- a/lib/hack-spirit.js
+++ b/lib/hack-spirit.js
@@ -1,5 +1,6 @@
 'use strict';
 let TeamSpirit = require('./team-spirit');
+let Credential = require('./credential');
 let co         = require('co');
 let WorkStatus = TeamSpirit.WorkStatus;
 let moment     = require('moment');
@@ -18,6 +19,25 @@ class HackSpirit {
   print(message) {
     console.log(message);
   }
+
+  login(userName, password) {
+    var self = this;
+    if (!userName || !password) {
+      self.print('user name or password is invalied');
+      self.dispose();
+      return;
+    }
+    co(function *() {
+      self.log('logging in... ');
+      yield self.teamSpiritClient.login(userName, password);
+      self.log('complete logging in... ');
+      self.dispose();
+      let credential = new Credential();
+      yield credential.set(userName, password);
+      self.print('Succeeded in saving your credentials!');
+    }).catch(self.onerror);
+  }
+
   printWorkStatus(userName, password) {
     var self = this;
     co(function *() {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "co": "^4.6.0",
     "commander": "^2.9.0",
     "date-utils": "^1.2.19",
+    "keychain": "^1.0.0",
     "moment": "^2.12.0",
-    "nightmare": "^2.2.0"
+    "nightmare": "^2.2.0",
+    "prompt": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "commander": "^2.9.0",
     "date-utils": "^1.2.19",
     "keychain": "^1.0.0",
+    "mkdirp": "^0.5.1",
     "moment": "^2.12.0",
     "nightmare": "^2.2.0",
+    "os-homedir": "^1.0.1",
     "prompt": "^1.0.0"
   }
 }


### PR DESCRIPTION
This pull request follows #5

Implement new `login` command:
- It saves credentials to persistent storage
  - For mac: keychain
  - otherwise: encryped json file 
- After you finish login command successfully, you don't need to add `--user` and `--password` options

Note: The behavior of login command is inspired by `heroku login` command
