### PR TITLE
Add colors dependency explicitly for windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "co": "^4.6.0",
+    "colors": "^1.1.2",
     "commander": "^2.9.0",
     "date-utils": "^1.2.19",
     "keychain": "^1.0.0",


### PR DESCRIPTION
hack-spirit  can run on windows!
However in my pc, nightmare is warned by event emitter :sob: 
But it works!
