### PR TITLE
Time report

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Currently, it provides these functionalities:
 - Report your delayed arrival
 - Record worktime
 - Have a break
+- Generate worktime report (weekly, monthly, specified period)
 
 ## Installation
 
@@ -45,6 +46,9 @@ You don't need to put the options `--user` and `--password` when once you login.
     break [options]         Record a break time
     breaked [options]       Record a break time until the time
     break_times [options]   Manage a break times
+    weekly [options]        Generate weekly worktime report
+    monthly [options]       Generate weekly worktime report
+    time_report [options]   Generate worktime report with a specified period
 
   Options:
 

--- a/bin/hack-spirit
+++ b/bin/hack-spirit
@@ -155,7 +155,7 @@ program
 
 program
   .command('weekly')
-  .description('Generate weekly report')
+  .description('Generate weekly worktime report')
   .option(`-d, --date [${dateFormat}]`, 'What day you want to record your worktime .(default: today)')
   .action((opts) => {
       let date = opts.date ? moment(opts.date, dateFormat).toDate() : new Date();
@@ -166,7 +166,7 @@ program
 
 program
   .command('monthly')
-  .description('Generate weekly report')
+  .description('Generate weekly worktime report')
   .option(`-d, --date [${dateFormat}]`, 'What day you want to record your worktime .(default: today)')
   .action((opts) => {
       let date = opts.date ? moment(opts.date, dateFormat).toDate() : new Date();
@@ -174,6 +174,20 @@ program
       let hackSpirit = new HackSpirit(program.browser, program.verbose);
       hackSpirit.monthlyReport(program.user, program.password, date);
   });
+
+program
+  .command('time_report')
+  .description('Generate worktime report with a specified period')
+  .option(`-f, --from [${dateFormat}]`, 'From date')
+  .option(`-t, --to [${dateFormat}]`, 'To date')
+  .action((opts) => {
+      let fromDate = opts.from ? moment(opts.from, dateFormat).toDate() : new Date();
+      let toDate   = opts.to   ? moment(opts.to  , dateFormat).toDate() : new Date();
+      let HackSpirit = require('../lib/hack-spirit');
+      let hackSpirit = new HackSpirit(program.browser, program.verbose);
+      hackSpirit.timeReport(program.user, program.password, fromDate, toDate);
+  });
+
 
 program
   .command('*', '', { noHelp: true})

--- a/bin/hack-spirit
+++ b/bin/hack-spirit
@@ -153,6 +153,27 @@ program
       hackSpirit.breakTimes(program.user, program.password, date);
   });
 
+program
+  .command('weekly')
+  .description('Generate weekly report')
+  .option(`-d, --date [${dateFormat}]`, 'What day you want to record your worktime .(default: today)')
+  .action((opts) => {
+      let date = opts.date ? moment(opts.date, dateFormat).toDate() : new Date();
+      let HackSpirit = require('../lib/hack-spirit');
+      let hackSpirit = new HackSpirit(program.browser, program.verbose);
+      hackSpirit.weeklyReport(program.user, program.password, date);
+  });
+
+program
+  .command('monthly')
+  .description('Generate weekly report')
+  .option(`-d, --date [${dateFormat}]`, 'What day you want to record your worktime .(default: today)')
+  .action((opts) => {
+      let date = opts.date ? moment(opts.date, dateFormat).toDate() : new Date();
+      let HackSpirit = require('../lib/hack-spirit');
+      let hackSpirit = new HackSpirit(program.browser, program.verbose);
+      hackSpirit.monthlyReport(program.user, program.password, date);
+  });
 
 program
   .command('*', '', { noHelp: true})

--- a/lib/hack-spirit.js
+++ b/lib/hack-spirit.js
@@ -165,7 +165,9 @@ class HackSpirit {
       }
 
       let cookies            = yield ts.login(userName, password);
-      let projectObjects     = yield ts.getProjects(date);
+      yield ts.openWorktimeDialog(date);
+      let projectObjects     = yield ts.getProjects();
+      yield ts.closeWorktimeDialog();
       let totalDuration      = yield ts.getTotalWorkDuration();
 
       self.print(`Total time is ${totalDuration.format("h:mm")}`);

--- a/lib/hack-spirit.js
+++ b/lib/hack-spirit.js
@@ -251,6 +251,61 @@ class HackSpirit {
     }).catch(self.onerror);
   }
 
+  weeklyReport(userName, password, date) {
+    let to   = moment(date);
+    let from = to.clone().subtract(7, 'days');
+    this.generateReport(userName, password, from, to);
+  }
+
+  monthlyReport(userName, password, date) {
+    let to   = moment(date);
+    let from = to.clone().date(1);
+    this.generateReport(userName, password, from, to);
+  }
+
+  generateReport(userName, password, from, to) {
+    let self = this;
+    let ts = self.teamSpiritClient;
+    co(function *() {
+      if (!userName || !password) {
+        let auth = yield new Credential().get();
+        if (!userName) userName = auth.userName;
+        if (!password) password = auth.password;
+      }
+
+      yield ts.login(userName, password);
+
+      const totalDuration = moment.duration(0);
+      const projectDurations = {};
+      for (let m = from; m.isBefore(to, 'days'); m = m.clone().add(1, 'days')) {
+        try {
+          yield ts.openWorktimeDialog(m.toDate());
+          let projectObjects = yield ts.getProjects();
+          yield ts.closeWorktimeDialog();
+          let duration      = yield ts.getTotalWorkDuration();
+          totalDuration.add(duration);
+          projectObjects.forEach((p) => {
+            if (projectDurations[p.name] === undefined) {
+              projectDurations[p.name] = moment.duration(0);
+            }
+            projectDurations[p.name].add(moment.duration(p.duration));
+          });
+        } catch (err) {
+          // it seems to be holiday
+        }
+      };
+      const options = { trim: false };
+      self.print('Worktime report ' +
+                 ` ${from.format('YYYYMMDD')} ~ ${to.format('YYYYMMDD')}:`);
+      self.print('total:' + totalDuration.format('h:mm', options));
+      _.keys(projectDurations).forEach((k) => {
+        self.print(`${k} ${projectDurations[k].format('h:mm', options)}`);
+      });
+      self.teamSpiritClient.dispose();
+      return Promise.resolve();
+    }).catch(self.onerror);
+  }
+
   * inputWorkTimeOfProjects(totalDuration, projectObjects) {
     let prompt = new Prompt();
     while (true) {

--- a/lib/hack-spirit.js
+++ b/lib/hack-spirit.js
@@ -6,6 +6,7 @@ let WorkStatus = TeamSpirit.WorkStatus;
 let moment     = require('moment');
 let Prompt     = require('./prompt');
 let Project    = require('./project');
+let _          = require('lodash');
 require("moment-duration-format");
 
 const supportUrl = 'https://github.com/aHirokiKumamoto/hack-spirit/issues/new';

--- a/lib/hack-spirit.js
+++ b/lib/hack-spirit.js
@@ -263,6 +263,13 @@ class HackSpirit {
     this.generateReport(userName, password, from, to);
   }
 
+  timeReport(userName, password, fromDate, toDate) {
+    let from = moment(fromDate);
+    let to   = moment(toDate);
+    console.log(toDate)
+    this.generateReport(userName, password, from, to);
+  }
+
   generateReport(userName, password, from, to) {
     let self = this;
     let ts = self.teamSpiritClient;

--- a/lib/team-spirit.js
+++ b/lib/team-spirit.js
@@ -246,11 +246,10 @@ class TeamSpirit {
     });
   }
 
-  * getProjects(date) {
-    let dateString             = date.toFormat('YYYY-MM-DD');
-    let buttonId = 'dailyWorkCell' + dateString;
-    let headerId = 'jobWorks_jobName_head';
-    let projects = yield this.needChangeMonth(date).then((needChangeMonth) => {
+  * openWorktimeDialog(date) {
+    let dateString = date.toFormat('YYYY-MM-DD');
+    let buttonId   = 'dailyWorkCell' + dateString;
+    yield this.needChangeMonth(date).then((needChangeMonth) => {
       if (needChangeMonth) {
         return this.gotoWorkTimePageAt(date);
       }
@@ -266,28 +265,36 @@ class TeamSpirit {
               'The day may be a holiday';
         throw new Error(message);
       }
-      return this.nightmare
-        .click(`#${buttonId}`)
-        .wait(`#${headerId}`)
-        .evaluate((headerId) => {
-          'use strict';
-          let cells = document.getElementsByClassName('name');
-          let projects = [];
-          for (let i = 0; i < cells.length; i++) {
-            if (cells[i].id !== headerId) {
-              let index = i - 1;
-              let input = document.getElementById(`empInputTime${index}`);
-              projects.push({
-                name: cells[i].textContent,
-                duration: input ? input.value : ''
-              });
-            }
-          }
-          return projects;
-        }, headerId);
+      return this.nightmare.click(`#${buttonId}`);
     });
+  }
+  * getProjects() {
+    let headerId = 'jobWorks_jobName_head';
+    let projects = yield this.nightmare
+      .wait(`#${headerId}`)
+      .evaluate((headerId) => {
+          'use strict';
+        let cells = document.getElementsByClassName('name');
+        let projects = [];
+        for (let i = 0; i < cells.length; i++) {
+          if (cells[i].id !== headerId) {
+            let index = i - 1;
+            let input = document.getElementById(`empInputTime${index}`);
+            projects.push({
+              name: cells[i].textContent,
+              duration: input ? input.value : ''
+            });
+          }
+        }
+        return projects;
+      }, headerId);
     return projects;
   }
+
+  * closeWorktimeDialog() {
+    yield this.nightmare.click('#empWorkCancel');
+  }
+
 
   * getTotalWorkDuration() {
     let id = 'empWorkRealTime';

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "commander": "^2.9.0",
     "date-utils": "^1.2.19",
     "keychain": "^1.0.0",
+    "lodash": "^4.13.1",
     "mkdirp": "^0.5.1",
     "moment": "^2.12.0",
     "moment-duration-format": "^1.3.0",


### PR DESCRIPTION
Implement #22 

weekly

```
  Usage: weekly [options]

  Generate weekly worktime report

  Options:

    -h, --help             output usage information
    -d, --date [YYYYMMDD]  What day you want to record your worktime .(default: today)
```

monthly

```
  Usage: monthly [options]

  Generate weekly worktime report

  Options:

    -h, --help             output usage information
    -d, --date [YYYYMMDD]  What day you want to record your worktime .(default: today)
```

any period

```
 Usage: time_report [options]

  Generate worktime report with a specified period

  Options:

    -h, --help             output usage information
    -f, --from [YYYYMMDD]  From date
    -t, --to [YYYYMMDD]    To date

```
